### PR TITLE
Add Support for 24-Hour Time Format in DayScheduleListWidget

### DIFF
--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -127,7 +127,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -171,10 +171,12 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -185,6 +187,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -272,7 +275,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -350,7 +353,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -399,7 +402,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -41,5 +41,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/example/lib/home_page.dart
+++ b/example/lib/home_page.dart
@@ -150,7 +150,7 @@ class _MyHomePageState extends State<MyHomePage> {
         padding: const EdgeInsets.all(5.0),
         child: Text(
           appointment.title,
-          style: Theme.of(context).textTheme.caption?.copyWith(
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 color: color,
               ),
         ),

--- a/example/lib/home_page.dart
+++ b/example/lib/home_page.dart
@@ -92,6 +92,9 @@ class _MyHomePageState extends State<MyHomePage> {
           timeOfDayColor: Colors.brown,
           updateAppointDuration: _updateAppointmentDuration,
           optionalChildWidthLine: 30,
+          startTime: const TimeOfDay(hour: 9, minute: 0),
+          endTime: const TimeOfDay(hour: 18, minute: 0),
+          is24Hours: true,
           optionalChildLine: (context, appointment, height) => Container(
             width: 30,
             height: height - 1,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,42 +5,48 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: "486b7bc707424572cdf7bd7e812a0c146de3fd47ecadf070254cc60383f21dd8"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
   day_schedule_list:
@@ -49,12 +55,13 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.4"
+    version: "0.4.6"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   flutter:
@@ -66,7 +73,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: b543301ad291598523947dc534aaddc5aaad597b709d2426d3a0e0d44c5cb493
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   flutter_test:
@@ -78,37 +86,42 @@ packages:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -118,51 +131,66 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=1.17.0"

--- a/lib/src/helpers/interval_range_utils.dart
+++ b/lib/src/helpers/interval_range_utils.dart
@@ -6,7 +6,7 @@ import 'package:day_schedule_list/src/models/schedule_time_of_day.dart';
 import 'package:flutter/material.dart';
 
 class IntervalRangeUtils {
-  static IntervalRange calculateItervalRangeForNewPosition({
+  static IntervalRange calculateIntervalRangeForNewPosition({
     required IntervalRange range,
     required ScheduleItemPosition newPosition,
     required ScheduleTimeOfDay firstValidTime,

--- a/lib/src/ui/day_schedule_list_widget.dart
+++ b/lib/src/ui/day_schedule_list_widget.dart
@@ -289,7 +289,7 @@ class DayScheduleListWidgetState<S extends IntervalRange>
     required double insetVertical,
   }) async {
     final appointment = appointments[index];
-    final newInterval = IntervalRangeUtils.calculateItervalRangeForNewPosition(
+    final newInterval = IntervalRangeUtils.calculateIntervalRangeForNewPosition(
       range: appointment,
       newPosition: newPosition,
       firstValidTime: validTimesList.first,
@@ -412,12 +412,12 @@ class DayScheduleListWidgetState<S extends IntervalRange>
 
   @override
   void onUpdateCancel() {
-    overlayController.hideAppoinmentOverlay();
+    overlayController.hideAppointmentOverlay();
   }
 
   @override
   void onUpdateEnd(ScheduleItemPosition position, int index) {
-    overlayController.hideAppoinmentOverlay();
+    overlayController.hideAppointmentOverlay();
     _updateAppointIntervalForNewPosition(
       index: index,
       appointments: widget.appointments,

--- a/lib/src/ui/day_schedule_list_widget.dart
+++ b/lib/src/ui/day_schedule_list_widget.dart
@@ -42,6 +42,8 @@ class DayScheduleListWidget<T extends IntervalRange> extends StatefulWidget {
     this.dragIndicatorBorderColor,
     this.customDragIndicator,
     this.is24Hours = false,
+    this.startTime = const TimeOfDay(hour: 8, minute: 30), // Default start time
+    this.endTime = const TimeOfDay(hour: 18, minute: 30), // Default end time
     Key? key,
   })  : assert(
           minimumMinuteInterval <= appointmentMinimumDuration,
@@ -137,6 +139,12 @@ class DayScheduleListWidget<T extends IntervalRange> extends StatefulWidget {
   /// Default value is false, meaning the 12-hour format is used by default.
   final bool is24Hours;
 
+  ///
+  final TimeOfDay startTime;
+
+  ///
+  final TimeOfDay endTime;
+
   @override
   DayScheduleListWidgetState<T> createState() =>
       DayScheduleListWidgetState<T>();
@@ -177,6 +185,8 @@ class DayScheduleListWidgetState<S extends IntervalRange>
     validTimesList = populateValidTimesList(
       unavailableIntervals: widget.unavailableIntervals,
       is24Hours: widget.is24Hours,
+      startTime: widget.startTime,
+      endTime: widget.endTime,
     );
     super.initState();
   }
@@ -197,6 +207,8 @@ class DayScheduleListWidgetState<S extends IntervalRange>
     validTimesList = populateValidTimesList(
       unavailableIntervals: widget.unavailableIntervals,
       is24Hours: widget.is24Hours,
+      startTime: widget.startTime,
+      endTime: widget.endTime,
     );
   }
 

--- a/lib/src/ui/day_schedule_list_widget.dart
+++ b/lib/src/ui/day_schedule_list_widget.dart
@@ -41,6 +41,7 @@ class DayScheduleListWidget<T extends IntervalRange> extends StatefulWidget {
     this.dragIndicatorColor,
     this.dragIndicatorBorderColor,
     this.customDragIndicator,
+    this.is24Hours = false,
     Key? key,
   })  : assert(
           minimumMinuteInterval <= appointmentMinimumDuration,
@@ -130,6 +131,12 @@ class DayScheduleListWidget<T extends IntervalRange> extends StatefulWidget {
   ///and [dragIndicatorBorderWidth] values are not used.
   final CustomDragIndicatorBuilder? customDragIndicator;
 
+  /// Determines whether the time should be displayed in 24-hour format.
+  /// When set to true, time will be displayed in 24-hour format (0:00 to 23:59).
+  /// When set to false, time will be displayed in 12-hour format with AM/PM indicators (12:00 AM to 11:59 PM).
+  /// Default value is false, meaning the 12-hour format is used by default.
+  final bool is24Hours;
+
   @override
   DayScheduleListWidgetState<T> createState() =>
       DayScheduleListWidgetState<T>();
@@ -169,6 +176,7 @@ class DayScheduleListWidgetState<S extends IntervalRange>
     );
     validTimesList = populateValidTimesList(
       unavailableIntervals: widget.unavailableIntervals,
+      is24Hours: widget.is24Hours,
     );
     super.initState();
   }
@@ -188,6 +196,7 @@ class DayScheduleListWidgetState<S extends IntervalRange>
     widget.appointments.sort((a, b) => a.start <= b.start ? -1 : 1);
     validTimesList = populateValidTimesList(
       unavailableIntervals: widget.unavailableIntervals,
+      is24Hours: widget.is24Hours,
     );
   }
 
@@ -246,8 +255,11 @@ class DayScheduleListWidgetState<S extends IntervalRange>
                 minimumMinuteInterval: minimumMinuteInterval,
                 minimumMinuteIntervalHeight: minimumMinuteIntervalHeight,
                 childWidthLine: widget.optionalChildWidthLine,
-                optionalChildLine: (appointment, height) => widget.optionalChildLine != null
-                  ? widget.optionalChildLine!(context, appointment, height) : Container(),
+                optionalChildLine: (appointment, height) => widget
+                            .optionalChildLine !=
+                        null
+                    ? widget.optionalChildLine!(context, appointment, height)
+                    : Container(),
               ),
             );
           },
@@ -319,8 +331,8 @@ class DayScheduleListWidgetState<S extends IntervalRange>
   }
 
   @override
-  bool canUpdateTo(ScheduleItemPosition position, int index,
-      AppointmentUpdateMode mode) {
+  bool canUpdateTo(
+      ScheduleItemPosition position, int index, AppointmentUpdateMode mode) {
     if (mode == AppointmentUpdateMode.position) {
       return canUpdatePositionOfInterval(
         newPosition: position,
@@ -362,7 +374,10 @@ class DayScheduleListWidgetState<S extends IntervalRange>
     } else if (windowSize.height >= 800) {
       sizeCalculation = 465;
     }
-    return windowSize.height - (newPosition.top + newPosition.height - currentScrollOffset) <= sizeCalculation && offsetIncrement >= 0;
+    return windowSize.height -
+                (newPosition.top + newPosition.height - currentScrollOffset) <=
+            sizeCalculation &&
+        offsetIncrement >= 0;
   }
 
   @override

--- a/lib/src/ui/interval_containers/appointment_container_overlay/appointment_overlay_controller.dart
+++ b/lib/src/ui/interval_containers/appointment_container_overlay/appointment_overlay_controller.dart
@@ -37,11 +37,11 @@ class AppointmentOverlayController {
     required double timeOfDayWidgetHeight,
   }) {
     appointmentOverlayPosition = ScheduleItemPosition.fromPosition(position);
-    hideAppoinmentOverlay();
+    hideAppointmentOverlay();
     appointmentOverlayEntry = OverlayEntry(
       builder: (BuildContext context) {
         final updatedInterval =
-            IntervalRangeUtils.calculateItervalRangeForNewPosition(
+            IntervalRangeUtils.calculateIntervalRangeForNewPosition(
           range: interval,
           newPosition: appointmentOverlayPosition,
           firstValidTime: validTimesList.first,
@@ -58,7 +58,7 @@ class AppointmentOverlayController {
           timeIndicatorsInset: GenericUtils.calculateTimeOfDayIndicatorsInset(
             timeOfDayWidgetHeight,
           ),
-          onTapToStopEditing: () => hideAppoinmentOverlay(),
+          onTapToStopEditing: () => hideAppointmentOverlay(),
           child: appointmentBuilder(
             context,
             interval,
@@ -68,7 +68,7 @@ class AppointmentOverlayController {
       },
     );
 
-    Overlay.of(context)?.insert(appointmentOverlayEntry!);
+    Overlay.of(context).insert(appointmentOverlayEntry!);
 
   }
 
@@ -78,7 +78,7 @@ class AppointmentOverlayController {
     appointmentOverlayEntry?.markNeedsBuild();
   }
 
-  void hideAppoinmentOverlay() {
+  void hideAppointmentOverlay() {
     try {
       final overlay = appointmentOverlayEntry;
       if (overlay != null) {

--- a/test/interval_range_utils_test.dart
+++ b/test/interval_range_utils_test.dart
@@ -104,7 +104,7 @@ void _calculateItervalRangeForNewPositionTest() {
         firstValidTime: validTimes.first,
       );
       expect(
-          IntervalRangeUtils.calculateItervalRangeForNewPosition(
+          IntervalRangeUtils.calculateIntervalRangeForNewPosition(
             range: originalAppointment,
             newPosition: newPosition,
             firstValidTime: validTimes.first,
@@ -128,7 +128,7 @@ void _calculateItervalRangeForNewPositionTest() {
         firstValidTime: validTimes.first,
       );
       expect(
-        IntervalRangeUtils.calculateItervalRangeForNewPosition(
+        IntervalRangeUtils.calculateIntervalRangeForNewPosition(
           range: originalAppointment,
           newPosition: newPosition,
           firstValidTime: validTimes.first,
@@ -153,7 +153,7 @@ void _calculateItervalRangeForNewPositionTest() {
         firstValidTime: validTimes.first,
       );
       expect(
-        IntervalRangeUtils.calculateItervalRangeForNewPosition(
+        IntervalRangeUtils.calculateIntervalRangeForNewPosition(
           range: originalAppointment,
           newPosition: newPosition,
           firstValidTime: validTimes.first,


### PR DESCRIPTION
This PR introduces the ability to display times in a 24-hour format within the DayScheduleListWidget. The addition of a boolean is24Hours parameter allows users to specify whether they want to display time in a 24-hour format or stick with the default 12-hour format with AM/PM indicators. This feature enhances the flexibility of the widget to cater to different regional preferences for time display.

### Changes:

- Added is24Hours parameter to DayScheduleListWidget and related classes.
- Updated populateValidTimesList method in DayScheduleListWidgetMixin to conditionally generate time slots based on the 24-hour format when is24Hours is true.
- Adjusted the widget and mixin to utilize the is24Hours flag for determining the time format to display.

### To-Do:

 

- [ ] Remove AM/PM indicators when is24Hours is set to true, ensuring a pure 24-hour time format is displayed.

This update ensures that the DayScheduleListWidget can be easily configured to match the time format preference of its users, improving its usability across different locales. The todo item highlights an ongoing enhancement to fully adapt the widget for 24-hour time display without AM/PM indicators, further aligning with user expectations in regions that predominantly use the 24-hour clock.